### PR TITLE
Add the ability to use multiple templates & paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,12 @@ The `consul-haproxy` command takes a number of CLI flags:
 * `-in`- Path to a template file. This is the template that is rendered
   to generate the configuration file at `-out`. It uses the Golang templating
   system. Docs for that are [here](http://golang.org/pkg/text/template/).
+  Can be provided multiple times. If specified multiple times, specify the
+  same number of paths with `-out`.
 
 * `-out` - Path to output configuration file. This path must be writable
-  by `consul-haproxy` or the file cannot be updated.
+  by `consul-haproxy` or the file cannot be updated. This can be specified
+  multiple times.
 
 * `-reload` - Command to invoke to reload configuration. This command can
   be any executable, and should be used to reload HAProxy. This is invoked
@@ -62,9 +65,11 @@ object with the following keys:
 * `backends` - A list of backend specifications. This is merged with any
   backends provided via the CLI.
 * `dry_run` - Same as `-dry` CLI flag.
-* `path` - Same as `-out` CLI flag.
+* `paths` - Same as `-out` CLI flag. . This value should be a list of paths and
+  is merged with any paths provided via the CLI.
 * `reload_command` - Same as `-reload` CLI flag.
-* `template` - Same as `-in` CLI flag.
+* `templates` - Same as `-in` CLI flag. This value should be a list of templates
+  and is merged with any paths provided via the CLI.
 * `quiet` - Same as `-quiet` CLI flag.
 * `max_wait` - Same as `-max-wait` CLI flag.
 
@@ -183,4 +188,3 @@ When this runs, we should see something like the following:
         server 1_sfo1-consul-2_consul 162.243.155.82:80
         server 1_sfo1-consul-1_consul 107.170.195.169:80
         server 1_sfo1-consul-3_consul 107.170.195.158:80
-

--- a/main_test.go
+++ b/main_test.go
@@ -51,10 +51,19 @@ func TestReadConfig(t *testing.T) {
 	if conf.Address != "127.0.0.2:8500" {
 		t.Fatalf("bad: %v", conf)
 	}
-	if conf.Template != "test-fixtures/simple.conf" {
+	templates := []string{
+		"test-fixtures/simple.conf",
+		"test-fixtures/second.conf",
+	}
+	if !reflect.DeepEqual(conf.Templates, templates) {
 		t.Fatalf("bad: %v", conf)
 	}
-	if conf.Path != "output.conf" {
+	paths := []string{
+		"output.conf",
+		"output2.conf",
+	}
+	if !reflect.DeepEqual(conf.Paths, paths) {
+
 		t.Fatalf("bad: %v", conf)
 	}
 	if conf.ReloadCommand != "echo 'foo' > reload_out" {

--- a/test-fixtures/config.json
+++ b/test-fixtures/config.json
@@ -1,8 +1,8 @@
 {
     "dry_run": true,
     "address": "127.0.0.2:8500",
-    "template": "test-fixtures/simple.conf",
-    "path": "output.conf",
+    "templates": ["test-fixtures/simple.conf", "test-fixtures/second.conf"],
+    "paths": ["output.conf", "output2.conf"],
     "reload_command": "echo 'foo' > reload_out",
     "backends": [
         "app=foo",

--- a/test-fixtures/second.conf
+++ b/test-fixtures/second.conf
@@ -6,11 +6,10 @@ defaults
 
 frontend http-in
     bind *:80
-    default_backend app
+    default_backend app2
 
-backend app
-    server node1_app 127.0.0.1:8000
-    server node3_app 127.0.0.3:8000
+backend app2{{range .app}}
+    {{.}}{{end}}
 
 listen admin
     bind *:8080

--- a/test-fixtures/second.conf.out
+++ b/test-fixtures/second.conf.out
@@ -6,9 +6,9 @@ defaults
 
 frontend http-in
     bind *:80
-    default_backend app
+    default_backend app2
 
-backend app
+backend app2
     server node1_app 127.0.0.1:8000
     server node3_app 127.0.0.3:8000
 

--- a/test-fixtures/simple.conf
+++ b/test-fixtures/simple.conf
@@ -14,4 +14,3 @@ backend app{{range .app}}
 listen admin
     bind *:8080
     stats enable
-


### PR DESCRIPTION
HAProxy allows for multiple configuration files on startup that are munged together. This commit changes consul-haproxy internally to maintain slices of templates and paths. Upon startup, it will validate the quantity of templates and paths match.

It also introduces a backwards incomaptible change to the configuration file format, changing the template and path attributes to templates and paths. These values should be a list of values instead of a single value.
